### PR TITLE
Update to HEMCO 3.5.1 for support with SE grids.

### DIFF
--- a/Externals_HCO.cfg
+++ b/Externals_HCO.cfg
@@ -1,5 +1,5 @@
 [hemco_src]
-tag = 3.5.0
+tag = 3.5.1
 protocol = git
 local_path = HEMCO
 repo_url = https://github.com/geoschem/hemco.git


### PR DESCRIPTION
Update HEMCO external to `3.5.1` for support with compiling in SE grids.