### PR TITLE
HEMCO-CESM 1.1.1 with HEMCO 3.6.2

### DIFF
--- a/Externals_HCO.cfg
+++ b/Externals_HCO.cfg
@@ -1,5 +1,5 @@
 [hemco_src]
-tag = 3.6.0
+tag = 3.6.2
 protocol = git
 local_path = HEMCO
 repo_url = https://github.com/geoschem/hemco.git

--- a/hco_cam_convert_state_mod.F90
+++ b/hco_cam_convert_state_mod.F90
@@ -495,6 +495,7 @@ contains
 
         ! Chemistry descriptor
         use chemistry,      only: chem_is
+        use mo_chem_utls,   only: get_rxt_ndx
 !
 ! !INPUT PARAMETERS:
 !
@@ -585,7 +586,7 @@ contains
 
             ! If they both exist, then create the pbuf fields... (hplin, 3/2/23)
             feat_Jvalues = .false.
-            if(rxt_jno2_idx > 0 .and. rxt_joh_idx > 0) then
+            if(index_rxt_jno2 > 0 .and. index_rxt_joh > 0) then
                 feat_Jvalues = .true.
                 call pbuf_add_field('HCO_IN_JNO2', 'global', dtype_r8, (/pcols/), index_JNO2)
                 call pbuf_add_field('HCO_IN_JOH',  'global', dtype_r8, (/pcols/), index_JOH )

--- a/hco_cam_convert_state_mod.F90
+++ b/hco_cam_convert_state_mod.F90
@@ -45,6 +45,9 @@ module hco_cam_convert_state_mod
     use ESMF,                     only: ESMF_KIND_R8, ESMF_KIND_I4, ESMF_SUCCESS
     use shr_kind_mod,             only: r8 => shr_kind_r8
 
+    ! Physics buffer
+    use physics_buffer, only: pbuf_add_field, dtype_r8
+
     implicit none
     private
 
@@ -126,6 +129,9 @@ module hco_cam_convert_state_mod
 !
     ! Flag for supported features
     logical                          :: feat_JValues
+
+    ! Indices for reactions (rxt) and pbuf fields
+    integer                          :: index_rxt_jno2, index_rxt_joh, index_JNO2, index_JOH
 
     ! On the CAM grid (state%psetcols, pver) (LM, my_CE)
     ! Arrays are flipped in order (k, i) for the regridder
@@ -497,7 +503,6 @@ contains
         ! CAM physics buffer (some fields are here and some are in phys state)
         use physics_buffer, only: pbuf_get_chunk, pbuf_get_field
         use physics_buffer, only: pbuf_get_index
-        use physics_buffer, only: pbuf_add_field, dtype_r8
 
         ! Time description and zenith angle data
         use orbit,          only: zenith
@@ -554,9 +559,6 @@ contains
 
         ! pbuf indices:
         integer                      :: index_pblh, index_JNO2, index_JOH
-
-        ! rxt indices:
-        integer                      :: index_rxt_jno2, index_rxt_joh
 
         ! Temporary geographical indices, allocated to max size (pcols)
         ! need to use actual column # ncol = get_ncols_p to fill to my_CE, which is exact

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -321,7 +321,7 @@ contains
             write(iulog,*) "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
             write(iulog,*) "HEMCO: Harmonized Emissions Component"
             write(iulog,*) "https://doi.org/10.5194/gmd-14-5487-2021 (Lin et al., 2021)"
-            write(iulog,*) "HEMCO_CAM interface version 1.1.0"
+            write(iulog,*) "HEMCO_CAM interface version 1.1.1"
             write(iulog,*) "You are using HEMCO version ", ADJUSTL(HCO_VERSION)
             write(iulog,*) "Config File: ", HcoConfigFile
             write(iulog,*) "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"


### PR DESCRIPTION
Now supports CAM-chem using HEMCO as runtime option.