### PR TITLE
Timestep, do not skip first step fixes; updates to debug printout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ This file documents all notable changes to the HEMCO-CESM interface since late 2
 
 ## [1.4.0] - TBD
 ### Added
-- Added git submodule capability with HEMCO as the only submodule
+- Added git submodule capability with HEMCO as the only submodule.
 
 ### Changed
-- Updated HEMCO submodule from version 3.8.1 to 3.9.0
+- **Based off upstream HEMCO 3.9.0**. Updated HEMCO submodule from version 3.8.1 to 3.9.0. Refer to HEMCO release notes.
+- First timestep now runs HEMCO as there is no longer issue with timestep measurement from prior versions.
 
 ### Removed
-- Removed support for manage_externals
+- Removed support for manage_externals.
+- Removed obsolete timestep measurement as timestep information is already obtained from time_manager reliably.
 
 ## [1.3.0] - 2024-04-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This is the official repository for the **HEMCO-CESM** interface, coupling the [
 
 :envelope: Maintainer: [Haipeng Lin](https://github.com/jimmielin) (hplin@seas.harvard.edu). Please post an issue or pull request in this repository if your request is code-related.
 
-## How to checkout
-HEMCO is fully implemented as an emissions component for [GEOS-Chem](https://gmd.copernicus.org/articles/15/8669/2022/) and [CAM-chem](https://wiki.ucar.edu/display/camchem/HEMCO) chemistry within CAM for [MUSICA](https://wiki.ucar.edu/display/MUSICA/MUSICA+Home). Simply download the latest release of CESM (2.3 and above) with CAM (6.3.118 and above) to use.
+## How to checkout and use:
+Currently HEMCO can only operate on a slightly modified version of CAM. The corresponding [pull request](https://github.com/ESCOMP/CAM/pull/560) is currently under discussion.
 
-This repository, `HEMCO_CESM`, is included as an external in CAM (`src/hemco`) and contains the interface for HEMCO to communicate with CAM. This repository then includes HEMCO itself as an external (`src/hemco/HEMCO`) which is model independent and shared by all models implementing HEMCO (GEOS-Chem, GEOS, CESM, WRF, etc.)
+**Warning: Unsupported CAM development code is unsupported. You have been warned.**
+
+The forked repository contains this repository as an external (`[hemco]`) to be deployed inside CAM in `cam/src/hemco`.
 
 ## Main components:
 * `/HEMCO/src/`: Contains the source for the [HEMCO emissions component](https://github.com/geoschem/HEMCO), imported using `manage_externals` (see `Externals_HCO.cfg`)
@@ -32,7 +34,7 @@ This repository, `HEMCO_CESM`, is included as an external in CAM (`src/hemco`) a
 
 ## License
 ```
-Copyright (c) 2019-2024, Haipeng Lin and Harvard University Atmospheric Chemistry Modeling Group.
+Copyright (c) 2019-2023, Haipeng Lin and Harvard University Atmospheric Chemistry Modeling Group.
 All rights reserved.
 
 This library is free software; you can redistribute it and/or

--- a/hco_esmf_grid.F90
+++ b/hco_esmf_grid.F90
@@ -798,9 +798,13 @@ contains
         ! Check if we need to update
         if(cam_last_atm_id == atm_id) then
             if(masterproc) then
-                write(iulog,*) ">> UpdateRegrid received ", atm_id, " already set"
+                write(iulog,'(A,I2)') "HEMCO_CESM: UpdateRegrid is already in atmospheric grid #", atm_id
             endif
             return
+        else
+            if(masterproc) then
+                write(iulog,'(A,I2)') "HEMCO_CESM: UpdateRegrid now updating for atmospheric grid #", atm_id
+            endif
         endif
 
         cam_last_atm_id = atm_id
@@ -913,7 +917,7 @@ contains
         endif
 
         if(masterproc) then
-            write(iulog,*) ">> HEMCO: FieldRegridStore four-way ready"
+            write(iulog,*) "HEMCO_CESM: FieldRegridStore four-way complete", atm_id
         endif
 
         ! Finished updating regrid routines

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -1448,7 +1448,7 @@ contains
         if(last_HCO_day * 86400.0 + last_HCO_second .ge. now_day * 86400.0 + now_s) then
             ! The first timestep should not be skipped. A fix is made during initialization (hplin, 6/11/24)
             if(masterproc) then
-                write(iulog,*) "HEMCO_CESM: !! HEMCO already ran for this time, check timestep mgr", now_day, now_s, last_HCO_day, last_HCO_second
+                write(iulog,*) "HEMCO_CESM: HEMCO already ran for this time, check timestep mgr (now day, s; last day, s)", now_day, now_s, last_HCO_day, last_HCO_second
             endif
 
             return
@@ -1475,11 +1475,10 @@ contains
         ! Update HEMCO clock
         ! using HcoClock_Set and not common SetHcoTime because we don't have DOY
         ! and we want HEMCO to do the math for us. oh well
-
-        !if(masterproc) then
-        !    write(6,*) "HEMCO_CESM: Updating HEMCO clock to set", year, month, day, hour, minute, second
-        !    write(6,*) "HEMCO_CESM: Internally HEMCO is at ", HcoState%Clock%SimHour, HcoState%Clock%SimMin, HcoState%Clock%SimSec, HcoState%Clock%nSteps
-        !endif
+        if(masterproc) then
+            write(iulog,'(A,I4,A,I2,A,I2,A,I2,A,I2,A,I2)') "HEMCO_CESM: Updating HEMCO clock to set (Y-M-D H:I:S)", year, "-", month, "-", day, " ", hour, ":", minute, ":", second
+            write(iulog,'(A,I4,A,I2,A,I2,A,I4)') "HEMCO_CESM: Internally HEMCO is at (Sim H:M:S:nStep)", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
+        endif
 
         call HCOClock_Set(HcoState, year, month, day,  &
                           hour, minute, second, IsEmisTime=.true., RC=HMRC)

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -365,7 +365,7 @@ contains
             write(iulog,*) "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
             write(iulog,*) "HEMCO: Harmonized Emissions Component"
             write(iulog,*) "https://doi.org/10.5194/gmd-14-5487-2021 (Lin et al., 2021)"
-            write(iulog,*) "HEMCO_CESM interface version 1.4.0"
+            write(iulog,*) "HEMCO_CESM interface version 2.0.0"
             write(iulog,*) "You are using HEMCO version ", ADJUSTL(HCO_VERSION)
             write(iulog,*) "ROOT: ", HcoRoot
             write(iulog,*) "Config File: ", HcoConfigFile

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -1475,8 +1475,8 @@ contains
         ! using HcoClock_Set and not common SetHcoTime because we don't have DOY
         ! and we want HEMCO to do the math for us. oh well
         if(masterproc) then
+            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I4.4)') "HEMCO_CESM: Internally HEMCO was at (Sim H:M:S:nStep) ", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
             write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2)') "HEMCO_CESM: Updating HEMCO clock to set (Y-M-D H:I:S) ", year, "-", month, "-", day, " ", hour, ":", minute, ":", second
-            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I4.4)') "HEMCO_CESM: Internally HEMCO is at (Sim H:M:S:nStep) ", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
         endif
 
         call HCOClock_Set(HcoState, year, month, day,  &

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -1475,8 +1475,8 @@ contains
         ! using HcoClock_Set and not common SetHcoTime because we don't have DOY
         ! and we want HEMCO to do the math for us. oh well
         if(masterproc) then
-            write(iulog,'(A,I4,A,I2,A,I2,A,I2,A,I2,A,I2)') "HEMCO_CESM: Updating HEMCO clock to set (Y-M-D H:I:S)", year, "-", month, "-", day, " ", hour, ":", minute, ":", second
-            write(iulog,'(A,I4,A,I2,A,I2,A,I4)') "HEMCO_CESM: Internally HEMCO is at (Sim H:M:S:nStep)", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
+            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2)') "HEMCO_CESM: Updating HEMCO clock to set (Y-M-D H:I:S) ", year, "-", month, "-", day, " ", hour, ":", minute, ":", second
+            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I4.4)') "HEMCO_CESM: Internally HEMCO is at (Sim H:M:S:nStep) ", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
         endif
 
         call HCOClock_Set(HcoState, year, month, day,  &

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -384,11 +384,10 @@ contains
         call get_curr_time(now_day, now_s)   ! 0 0
         call get_curr_date(year, month, day, tod) ! 2005 1 1 0
 
-        ! In order to allow first timestep to be ran, now use prev time from ESMF
-        ! which is time at beginning of timestep, as initialization time.
-        ! This should also improve the situation for restarts.
-        last_HCO_day    = prev_day
-        last_HCO_second = prev_s
+        ! In order to allow first timestep to be ran, set last HEMCO day and hour to
+        ! negative at initialization. prev_time from ESMF is always zero.
+        last_HCO_day    = -1
+        last_HCO_second = -1
         write(iulog,*) "HEMCO debug: prev_day, prev_s, now_day, now_s, y, m, d, tod", prev_day, prev_s, now_day, now_s, year, month, day, tod
 
         !-----------------------------------------------------------------------


### PR DESCRIPTION
Updates to HEMCO_CESM interface:
* Remove legacy way of measuring t+1 and t for dt, now uses reliable timestep from time_manager
* Do not skip first timestep for computing emissions
* Updates to debug printout