### PR TITLE
Restrict read prints if using MPI

### DIFF
--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -519,7 +519,7 @@ contains
         ! We are using pcnst here, which is # of constituents.
         nHcoSpc             = pcnst          ! # of hco species?
 
-        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc)
+        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc, outLUN=iulog)
         ASSERT_(HMRC==HCO_SUCCESS)
 
         HcoConfig%amIRoot   = masterproc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR passes log LUN iulog to HEMCO during configuration initialization. This enable sending HEMCO prints to the CAM log `atm.log` rather than `cesm.log` and/or a dedicated HEMCO log.

Todo: Update HEMCO configuration file to fix bug in verbose and remove line for HEMCO log filename.

**Note that this update will require an update within the HEMCO submodule.**

### Expected changes

This is a no diff update other than reduced prints in the cesm log.

### Reference(s)

None

### Related Github Issue

Companion HEMCO submodule PR (required): https://github.com/geoschem/HEMCO/pull/296