### PR TITLE
Update .gitmodules to work with fleximod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "HEMCO"]
 	path = HEMCO
 	url = https://github.com/geoschem/hemco.git
+	fxrequired = AlwaysRequired
+	fxtag = 3.9.0
+	fxDONOTUSEurl = https://github.com/geoschem/hemco.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file documents all notable changes to the HEMCO-CESM interface since late 2022.
 
 ## [2.0.1] - TBD
+### Added
+- Added fleximod capability to .gitmodules
+
 ### Changed
 - Added new default configuration file for HEMCO which reads/regrids 3D emissions hourly
 - Updated debug printout and message for where to find error messages


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates .gitmodules to use fleximod. Several of the required lines were omitted when first added.

### Expected changes

Fleximod will checkout the HEMCO tag specified in .gitmodules. Using git submodules will no longer be required to checkout  HEMCO version.

### Reference(s)

None

### Related Github Issue

None (?)