### PR TITLE
Update to HEMCO 3.10.1 and send HEMCO prints to atm.log

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = HEMCO
 	url = https://github.com/geoschem/hemco.git
 	fxrequired = AlwaysRequired
-	fxtag = 3.9.0
+	fxtag = 3.10.1
 	fxDONOTUSEurl = https://github.com/geoschem/hemco.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ This file documents all notable changes to the HEMCO-CESM interface since late 2
 ## [2.0.1] - TBD
 ### Added
 - Added fleximod capability to .gitmodules
+- Added print target LUN for atm.log to arguments passed to HEMCO ConfigInit to direct HEMCO root prints to atm.log rathe rather than cesm.llog
 
 ### Changed
 - Added new default configuration file for HEMCO which reads/regrids 3D emissions hourly
 - Updated debug printout and message for where to find error messages
+- Updated HEMCO submodule from 3.9.0 to 3.10.1
 
 ### Fixed
 - Fixed HEMCO clock to be time at start of timestep rather than end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents all notable changes to the HEMCO-CESM interface since late 2
 ## [2.0.1] - TBD
 ### Added
 - Added fleximod capability to .gitmodules
-- Added print target LUN for atm.log to arguments passed to HEMCO ConfigInit to direct HEMCO root prints to atm.log rathe rather than cesm.llog
+- Added print target LUN for atm.log to arguments passed to HEMCO ConfigInit to direct HEMCO root prints to atm.log rathe rather than cesm.log
 
 ### Changed
 - Added new default configuration file for HEMCO which reads/regrids 3D emissions hourly

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -516,7 +516,7 @@ contains
         ! We are using pcnst here, which is # of constituents.
         nHcoSpc             = pcnst          ! # of hco species?
 
-        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc)
+        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc, outLUN=iulog)
         ASSERT_(HMRC==HCO_SUCCESS)
 
         HcoConfig%amIRoot   = masterproc

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -516,7 +516,7 @@ contains
         ! We are using pcnst here, which is # of constituents.
         nHcoSpc             = pcnst          ! # of hco species?
 
-        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc, outLUN=iulog)
+        call ConfigInit(HcoConfig, HMRC, nModelSpecies=nHcoSpc, stdLogLUN=iulog)
         ASSERT_(HMRC==HCO_SUCCESS)
 
         HcoConfig%amIRoot   = masterproc
@@ -600,12 +600,6 @@ contains
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
-
-        ! Open the HEMCO log file (if using)
-        if(masterproc) then
-            call HCO_LOGFILE_OPEN(HcoConfig%Err, RC=HMRC)
-            ASSERT_(HMRC==HCO_SUCCESS)
-        endif
 
         call Config_ReadFile(HcoConfig%amIRoot, HcoConfig, HcoConfigFile, 2, HMRC, IsDryRun=.false.)
         if(masterproc .and. HMRC /= HCO_SUCCESS) then


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates the HEMCO submodule from 3.9.0 to 3.10.1. It also updates the call to HEMCO subroutine `ConfigInit` to pass the identifier of `atm.log`. This results in HEMCO writing to `atm.log` rather than `cesm.log` as long as the target LUN in HEMCO is `HcoState%Config%stdLogLUN` or `HcoState%Config%hcoLogLUN` and the print is called from the root thread. By default all prints in HEMCO currently meet this criteria. If `Verbose` is enabled in `HEMCO_Config.rc` then prints can be extended to all cores if `VerboseOnCores` is changed to `all` in the configuration file. However, the non-root prints will go to `cesm.log`.

### Expected changes

See the HEMCO [CHANGELOG.md](https://github.com/geoschem/HEMCO/blob/main/CHANGELOG.md) for summary of changes since version 3.9.0.

### Reference(s)

none

### Related Github Issue

none
