### PR TITLE
Enable b4b reproducibility in ESMF regridding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This file documents all notable changes to the HEMCO-CESM interface since late 2022.
 
-## [2.0.1] - TBD
+## [2.1.1] - TBD
+### Fixed
+ - Enable b4b reproducibility in all CAM <-> HCO regridding by passing srcTermProcessing=1 to ESMF_RegridFieldStore
+
+## [2.1.0] - 2024-12-16
 ### Added
 - Added fleximod capability to .gitmodules
 - Added print target LUN for atm.log to arguments passed to HEMCO ConfigInit to direct HEMCO root prints to atm.log rathe rather than cesm.log

--- a/hco_esmf_grid.F90
+++ b/hco_esmf_grid.F90
@@ -860,7 +860,7 @@ contains
             poleMethod=ESMF_POLEMETHOD_ALLAVG,                     &
             extrapMethod=ESMF_EXTRAPMETHOD_NEAREST_IDAVG,          &
             routeHandle=CAM2HCO_RouteHandle_2D,                    &
-            !srcTermProcessing=smm_srctermproc,                     &
+            srcTermProcessing=smm_srctermproc,                     &
             pipelineDepth=smm_pipelinedep, rc=RC)
         ASSERT_(RC==ESMF_SUCCESS)
 
@@ -877,7 +877,7 @@ contains
             poleMethod=ESMF_POLEMETHOD_ALLAVG,                     &
             extrapMethod=ESMF_EXTRAPMETHOD_NEAREST_IDAVG,          &
             routeHandle=CAM2HCO_RouteHandle_3D,                    &
-            !srcTermProcessing=smm_srctermproc,                     &
+            srcTermProcessing=smm_srctermproc,                     &
             pipelineDepth=smm_pipelinedep, rc=RC)
         ASSERT_(RC==ESMF_SUCCESS)
 
@@ -892,7 +892,7 @@ contains
             regridMethod=ESMF_REGRIDMETHOD_CONSERVE    ,           &
             poleMethod=ESMF_POLEMETHOD_NONE,                       &
             routeHandle=HCO2CAM_RouteHandle_2D,                    &
-            !srcTermProcessing=smm_srctermproc,                     &
+            srcTermProcessing=smm_srctermproc,                     &
             pipelineDepth=smm_pipelinedep, rc=RC)
         ASSERT_(RC==ESMF_SUCCESS)
 
@@ -909,7 +909,7 @@ contains
             regridMethod=ESMF_REGRIDMETHOD_CONSERVE    ,           &
             poleMethod=ESMF_POLEMETHOD_NONE,                       &
             routeHandle=HCO2CAM_RouteHandle_3D,                    &
-            !srcTermProcessing=smm_srctermproc,                     &
+            srcTermProcessing=smm_srctermproc,                     &
             pipelineDepth=smm_pipelinedep, rc=RC)
         ASSERT_(RC==ESMF_SUCCESS)
 


### PR DESCRIPTION
### Name and Institution

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR passes term srcTermProcessing with value 1 to ESMF_RegridFieldStore to enable bit-for-bit reproducibility in CAM <-> HEMCO ESMF regridding. Previously passing this term was commented out for unknown reasons.

### Expected changes

This is one of several updates to work towards bit-for-bit reproducibility of CAM output when using HEMCO with CAM-chem.   It removes the potential for numerical noise when using ESMF to regrid between the CAM and HEMCO grids.

### Reference(s)

none

### Related Github Issue

https://github.com/ESCOMP/CAM/issues/856
