### PR TITLE
Merge HEMCO_CESM 2.1.0 into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Externals
-HEMCO
-
 # Prerequisites
 *.d
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "HEMCO"]
+	path = HEMCO
+	url = https://github.com/geoschem/hemco.git
+	fxrequired = AlwaysRequired
+	fxtag = 3.9.0
+	fxDONOTUSEurl = https://github.com/geoschem/hemco.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents all notable changes to the HEMCO-CESM interface since late 2022.
 
+## [2.0.1] - TBD
+### Added
+- Added fleximod capability to .gitmodules
+
+### Changed
+- Added new default configuration file for HEMCO which reads/regrids 3D emissions hourly
+- Updated debug printout and message for where to find error messages
+
+### Fixed
+- Fixed HEMCO clock to be time at start of timestep rather than end
+- Fixed formatting for Ap/Bp printout
+- Fixed condition for first timestep to ensure HEMCO is not run at timestep 0
+
+## [2.0.0] - 2024-07-31
+### Added
+- Added git submodule capability with HEMCO as the only submodule.
+
+### Changed
+- Update README
+- Run HEMCO starting in first step
+- Updates to debug printout
+- **Based off upstream HEMCO 3.9.0**. Updated HEMCO submodule from version 3.8.1 to 3.9.0. Refer to HEMCO release notes.
+- First timestep now runs HEMCO as there is no longer issue with timestep measurement from prior versions.
+
+### Removed
+- Removed support for manage_externals.
+- Removed obsolete timestep measurement as timestep information is already obtained from time_manager reliably.
+- Removed support for manage_externals.
+- Removed obsolete timestep measurement as timestep information is already obtained from time_manager reliably.
+
 ## [1.3.0] - 2024-04-29
 ### Added
 - Performance timers using CIME infrastructure for initialization and run of major HEMCO_CESM and HEMCO components.

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,0 @@
-[externals_description]
-schema_version = 1.0.0
-
-[cam]
-local_path = .
-protocol = externals_only
-externals = Externals_HCO.cfg
-required = True
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the official repository for the **HEMCO-CESM** interface, coupling the [
 :envelope: Maintainer: [Haipeng Lin](https://github.com/jimmielin) (hplin@seas.harvard.edu). Please post an issue or pull request in this repository if your request is code-related.
 
 ## How to checkout
-HEMCO is fully implemented as an emissions component for [GEOS-Chem](https://gmd.copernicus.org/articles/15/8669/2022/) and [CAM-chem](https://wiki.ucar.edu/display/camchem/HEMCO) chemistry within CAM for [MUSICA](https://wiki.ucar.edu/display/MUSICA/MUSICA+Home). Simply download the latest release of CESM (2.3 and above) with CAM (6.3.118 and above) to use.
+HEMCO is fully implemented as an emissions component for [GEOS-Chem](https://gmd.copernicus.org/articles/15/8669/2022/) and [CAM-chem](https://wiki.ucar.edu/display/camchem/HEMCO) chemistry within CAM for [MUSICA](https://wiki.ucar.edu/display/MUSICA/MUSICA+Home) starting with CESM 2.3 with CAM 6.3.118.
 
 This repository, `HEMCO_CESM`, is included as an external in CAM (`src/hemco`) and contains the interface for HEMCO to communicate with CAM. This repository then includes HEMCO itself as an external (`src/hemco/HEMCO`) which is model independent and shared by all models implementing HEMCO (GEOS-Chem, GEOS, CESM, WRF, etc.)
 
@@ -29,6 +29,16 @@ This repository, `HEMCO_CESM`, is included as an external in CAM (`src/hemco`) a
 
 ### Configuration files
 ...are available in the [HEMCO_CESM_configs](https://github.com/jimmielin/HEMCO_CESM_configs) repository with [instructions on how to translate GEOS-Chem emission species to CAM-chem](https://github.com/jimmielin/HEMCO_CESM_configs/blob/master/CAM-Chem/Mapping_Process.md).
+
+### Contribution Guide/Branches
+* `main` will always represent the latest code merged into `cam_development`.
+* `development` is the development trunk, where latest code and features are available but not yet available in `cam_development`. Releases are tagged from this branch.
+* `dev/*` are feature branches where development happens. The contents of these branches are submitted to `development` via pull requests.
+
+Releases are named in the format `hemco-cesmX_Y_Z_hemco3_9_0` where `X.Y.Z` is the semantic versioning of the HEMCO-CESM **interface** release (See `CHANGELOG.md`) and the suffix is the accompanying HEMCO version.
+* `X` represents breaking, backwards-incompatible changes.
+* `Y` represents backwards-compatible major releases.
+* `Z` represents backwards-compatible bug fixes, including minor releases with changes only in the HEMCO external.
 
 ## License
 ```

--- a/hco_esmf_grid.F90
+++ b/hco_esmf_grid.F90
@@ -434,9 +434,9 @@ contains
 
             write( iulog, '(a)'   ) REPEAT( '=', 79 )
             write( iulog, '(a,/)' ) 'V E R T I C A L   G R I D   S E T U P'
-            write( iulog, '( ''Ap '', /, 6(f11.6,1x) )' ) AP(1:LM+1)
+            write( iulog, '( ''Ap '', /, 6(f14.6,1x) )' ) AP(1:LM+1)
             write( iulog, '(a)'   )
-            write( iulog, '( ''Bp '', /, 6(f11.6,1x) )' ) BP(1:LM+1)
+            write( iulog, '( ''Bp '', /, 6(f14.6,1x) )' ) BP(1:LM+1)
             write( iulog, '(a)'   ) REPEAT( '=', 79 )
         endif
 
@@ -690,11 +690,12 @@ contains
 
         if(masterproc) then
             ! Output information on the decomposition
-            write(iulog,*) ">> HEMCO DEBUG - Committed HCO_Tasks decomposition"
-            write(iulog,*) "nPET, nPET_lon, nPET_lat", nPET, nPET_lon, nPET_lat
+            write(iulog,*) "Committed HCO_Tasks decomposition:"
+            write(iulog,*) "nPET = ", nPET, ", nPET_lon = ", nPET_lon, ", nPET_lat = ",  nPET_lat
             do N = 0, nPET-1
-                write(iulog,*) "PET", N, " ID", HCO_Tasks(N)%ID, " ID_I", HCO_Tasks(N)%ID_I, " ID_J", HCO_Tasks(N)%ID_J, &
-                               "IM (IS,IE)", HCO_Tasks(N)%IM, HCO_Tasks(N)%IS, HCO_Tasks(N)%IE, " // JM (JS, JE)", HCO_Tasks(N)%JM, HCO_Tasks(N)%JS, HCO_Tasks(N)%JE
+                ! more info to print if needed
+                !write(iulog,*) "PET", N, " ID", HCO_Tasks(N)%ID, " ID_I", HCO_Tasks(N)%ID_I, " ID_J", HCO_Tasks(N)%ID_J, &
+                !               "IM (IS,IE)", HCO_Tasks(N)%IM, HCO_Tasks(N)%IS, HCO_Tasks(N)%IE, " // JM (JS, JE)", HCO_Tasks(N)%JM, HCO_Tasks(N)%JS, HCO_Tasks(N)%JE
             enddo
         endif
 
@@ -798,9 +799,13 @@ contains
         ! Check if we need to update
         if(cam_last_atm_id == atm_id) then
             if(masterproc) then
-                write(iulog,*) ">> UpdateRegrid received ", atm_id, " already set"
+                write(iulog,'(A,I2)') "HEMCO_CESM: UpdateRegrid is already in atmospheric grid #", atm_id
             endif
             return
+        else
+            if(masterproc) then
+                write(iulog,'(A,I2)') "HEMCO_CESM: UpdateRegrid now updating for atmospheric grid #", atm_id
+            endif
         endif
 
         cam_last_atm_id = atm_id
@@ -913,7 +918,7 @@ contains
         endif
 
         if(masterproc) then
-            write(iulog,*) ">> HEMCO: FieldRegridStore four-way ready"
+            write(iulog,*) "HEMCO_CESM: FieldRegridStore four-way complete", atm_id
         endif
 
         ! Finished updating regrid routines

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -59,7 +59,8 @@ module hemco_interface
     use ppgrid,                   only: begchunk, endchunk ! Chunk idxs
 
     ! Time
-    use time_manager,             only: get_curr_time, get_prev_time, get_curr_date
+    use time_manager,             only: get_prev_time, get_prev_date
+    use time_manager,             only: get_curr_time, get_curr_date
     use time_manager,             only: get_step_size
 
     ! ESMF types
@@ -147,10 +148,6 @@ module hemco_interface
 
     ! HEMCO configuration parameters that are set by namelist in CESM
     integer                          :: HcoFixYY            ! if > 0, force 'Emission year'
-
-    ! Last execution times for the HEMCO component. We are assuming that time
-    ! flows unidirectionally (and forwards, for now). (hplin, 3/30/20)
-    integer                          :: last_HCO_day, last_HCO_second
 
     ! Meteorological fields used by HEMCO to be regridded to the HEMCO grid (hplin, 3/31/20)
     ! We have to store the fields because the regridding can only take place within the GridComp.
@@ -344,9 +341,8 @@ contains
         character(len=128)           :: exportNameTmp
 
         ! Timing properties
-        integer                      :: year, month, day, tod
-        integer                      :: hour, minute, second, dt
-        integer                      :: prev_day, prev_s, now_day, now_s
+        integer                      :: ts0_year, ts0_month, ts0_day, ts0_tod, ts0_s ! timestep start
+        integer                      :: ts1_year, ts1_month, ts1_day, ts1_tod, ts1_s ! timestep end
         integer                      :: stepsize_tmp
 
         ! Temporaries
@@ -364,12 +360,10 @@ contains
         if(masterproc) then
             write(iulog,*) "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
             write(iulog,*) "HEMCO: Harmonized Emissions Component"
-            write(iulog,*) "https://doi.org/10.5194/gmd-14-5487-2021 (Lin et al., 2021)"
-            write(iulog,*) "HEMCO_CESM interface version 1.3.0"
             write(iulog,*) "You are using HEMCO version ", ADJUSTL(HCO_VERSION)
-            write(iulog,*) "ROOT: ", HcoRoot
-            write(iulog,*) "Config File: ", HcoConfigFile
-            write(iulog,*) "Diagn File: ", HcoDiagnFile
+            write(iulog,*) "ROOT: ", TRIM(HcoRoot)
+            write(iulog,*) "Config File: ", TRIM(HcoConfigFile)
+            write(iulog,*) "Diagn File: ", (HcoDiagnFile)
             write(iulog,*) "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
         endif
 
@@ -380,12 +374,18 @@ contains
         !-----------------------------------------------------------------------
         ! Get time properties
         !-----------------------------------------------------------------------
-        call get_prev_time(prev_day, prev_s) ! 0 0
-        call get_curr_time(now_day, now_s)   ! 0 0
-        call get_curr_date(year, month, day, tod) ! 2005 1 1 0
 
-        last_HCO_day    = now_day
-        last_HCO_second = now_s   ! This means first timestep is not ran
+        ! Optional prints to understand CAM time
+        !if(masterproc) then
+        !   call get_prev_time(ts0_day, ts0_s)
+        !   call get_prev_date(ts0_year, ts0_month, ts0_day, ts0_tod)
+        !   call get_curr_time(ts1_day, ts1_s)
+        !   call get_curr_date(ts1_year, ts1_month, ts1_day, ts1_tod)
+        !   write(iulog,*) "HEMCO_CESM debug (init): CAM date at start of timestep: year, month, day, tod: ", ts0_year, ts0_month, ts0_day, ts0_tod
+        !   write(iulog,*) "HEMCO_CESM debug (init): CAM date at end of timestep: year, month, day, tod: ", ts1_year, ts1_month, ts1_day, ts1_tod
+        !   write(iulog,*) "HEMCO_CESM debug (init): CAM time at start of timestep: day, s: ", ts0_day, ts0_s
+        !   write(iulog,*) "HEMCO_CESM debug (init): CAM time at end of timestep: day, s: n", ts1_day, ts1_s
+        !endif
 
         !-----------------------------------------------------------------------
         ! Setup ESMF wrapper gridded component
@@ -595,14 +595,13 @@ contains
             write(iulog,*) "This may be due to misconfiguration of the"
             write(iulog,*) "hemco_config_file namelist variable, or a"
             write(iulog,*) "misformatted HEMCO configuration file."
-            write(iulog,*) "Please refer to the HEMCO.log log file in your"
-            write(iulog,*) "case run directory or as configured in HEMCO_Config.rc"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in your"
+            write(iulog,*) "case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
 
-        ! Open the log file
+        ! Open the HEMCO log file (if using)
         if(masterproc) then
             call HCO_LOGFILE_OPEN(HcoConfig%Err, RC=HMRC)
             ASSERT_(HMRC==HCO_SUCCESS)
@@ -617,9 +616,8 @@ contains
             write(iulog,*) "This may be due to misconfiguration of the"
             write(iulog,*) "hemco_config_file namelist variable, or a"
             write(iulog,*) "misformatted HEMCO configuration file."
-            write(iulog,*) "Please refer to the HEMCO.log log file in your"
-            write(iulog,*) "case run directory or as configured in HEMCO_Config.rc"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in your"
+            write(iulog,*) "case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
@@ -849,9 +847,8 @@ contains
             write(iulog,*) "HEMCO could not be initialized."
             write(iulog,*) "This may be due to misconfiguration of the"
             write(iulog,*) "HEMCO configuration file."
-            write(iulog,*) "Please refer to the HEMCO.log log file and"
-            write(iulog,*) "the cesm.log. log files in your case run directory"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in"
+            write(iulog,*) "your case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
@@ -1370,10 +1367,10 @@ contains
         real(ESMF_KIND_R8)                    :: dummy_2(my_IS:my_IE, my_JS:my_JE)
 
         ! Timing properties
-        integer                               :: year, month, day, tod
+        integer                               :: ts0_year, ts0_month, ts0_day, ts0_tod, ts0_s
+        integer                               :: ts1_year, ts1_month, ts1_day, ts1_tod, ts1_s
         integer                               :: hour, minute, second
-        integer                               :: prev_day, prev_s, now_day, now_s
-        integer                               :: tmp_currTOD
+        integer                               :: tmp_ts0_TOD
 
         ! HEMCO vertical grid property pointers
         ! NOTE: Hco_CalcVertGrid expects pointer-based arguments, so we must
@@ -1391,6 +1388,7 @@ contains
         integer                      :: HMRC
 
         logical, save                :: FIRST = .True.
+        logical, save                :: isTimestepping = .False.
         logical                      :: doExport = .False.
         integer, save                :: nCalls = 0
 
@@ -1424,71 +1422,55 @@ contains
         endif
 
         !-----------------------------------------------------------------------
-        ! Get time properties
+        ! Get time properties. Current time is time at end of current timestep.
+        ! Previous time is time at start of current timestep. Use these
+        ! to do checks and set HEMCO clock.
         !-----------------------------------------------------------------------
-        call get_prev_time(prev_day, prev_s)
-        call get_curr_time(now_day, now_s)
-        call get_curr_date(year, month, day, tod)
+        call get_prev_time(ts0_day, ts0_s)
+        call get_prev_date(ts0_year, ts0_month, ts0_day, ts0_tod)
 
-        !if(masterproc) then
-        !    write(iulog,*) "hco year,month,day,tod", year, month, day, tod
-        !    write(iulog,*) "hco prev_day, prev_s", prev_day, prev_s
-        !    write(iulog,*) "hco now_day, now_s", now_day, now_s
-        !endif
-        ! 2005 1 1 1800 | 0 0 | 0 1800
-        ! 2005 1 1 3600 | 0 1800 | 0 3600
-        ! 2005 1 1 5400 | 0 3600 | 0 5400
-        ! ...
-
-        ! Check if we have run HEMCO for this time step already. If yes can exit
-        if(last_HCO_day * 86400.0 + last_HCO_second .ge. now_day * 86400.0 + now_s) then
-            ! But also do not skip the first time step
-            ! FIXME: Implicit assumption of time stepping size being 1800.0
-            ! FIXME hplin 2/28/21
-
-            if(masterproc) then
-                write(iulog,*) "HEMCO_CESM: !! HEMCO already ran for this time, check timestep mgr", now_day, now_s, last_HCO_day, last_HCO_second
-            endif
-
-            return
+        ! Check if timestepping has begun by comparing current (end of timestep) and previous (start of timestep) times
+        if ( .not. isTimestepping ) then
+           call get_curr_time(ts1_day, ts1_s)
+           call get_curr_date(ts1_year, ts1_month, ts1_day, ts1_tod)
+           !if(masterproc) then
+           !   write(iulog,*) "HEMCO_CESM debug: CAM date at start of timestep: year, month, day, tod: ", ts0_year, ts0_month, ts0_day, ts0_tod
+           !   write(iulog,*) "HEMCO_CESM debug: CAM date at end of timestep: year, month, day, tod: ", ts1_year, ts1_month, ts1_day, ts1_tod
+           !   write(iulog,*) "HEMCO_CESM debug: CAM time at start of timestep: day, s: ", ts0_day, ts0_s
+           !   write(iulog,*) "HEMCO_CESM debug: CAM time at end of timestep: day, s: ", ts1_day, ts1_s
+           !endif
+           if ( ( ts0_day == ts1_day ) .and. ( ts0_s == ts1_s ) ) then
+              if(masterproc) write(iulog,*) "HEMCO_CESM: CAM current and previous times are the same. Do not run HEMCO yet."
+              return
+           else
+              isTimestepping = .True.
+           endif
         endif
 
-        ! Compute timestep
-        if(HcoState%TS_CHEM .ne. ((now_day - prev_day) * 86400.0 + now_s - prev_s)) then
-            HcoState%TS_EMIS = (now_day - prev_day) * 86400.0 + now_s - prev_s
-            HcoState%TS_CHEM = (now_day - prev_day) * 86400.0 + now_s - prev_s
-            HcoState%TS_DYN  = (now_day - prev_day) * 86400.0 + now_s - prev_s
-
-            if(masterproc) then
-                write(iulog,*) "HEMCO_CESM: Updated HEMCO timestep to ", HcoState%TS_CHEM
-            endif
-        endif
-
-        ! Compute hour, minute, second (borrowed from tfritz)
-        tmp_currTOD = tod
+        ! Compute previous hour, minute, second which is time at timestep start
+        tmp_ts0_TOD = ts0_tod
         hour = 0
         minute = 0
-        do while(tmp_currTOD >= 3600)
-            tmp_currTOD = tmp_currTOD - 3600
+        do while(tmp_ts0_TOD >= 3600)
+            tmp_ts0_TOD = tmp_ts0_TOD - 3600
             hour = hour + 1
         enddo
 
-        do while(tmp_currTOD >= 60)
-            tmp_currTOD = tmp_currTOD - 60
+        do while(tmp_ts0_TOD >= 60)
+            tmp_ts0_TOD = tmp_ts0_TOD - 60
             minute = minute + 1
         enddo
-        second = tmp_currTOD
+        second = tmp_ts0_TOD
 
-        ! Update HEMCO clock
-        ! using HcoClock_Set and not common SetHcoTime because we don't have DOY
-        ! and we want HEMCO to do the math for us. oh well
+        ! Update HEMCO clock to time at start of timestep which is CAM previous time.
+        ! Use HcoClock_Set and not common SetHcoTime because we don't have DOY
+        ! and we want HEMCO to do the math for us.
+        if(masterproc) then
+            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I4.4)') "HEMCO_CESM: Internally HEMCO was at (Sim H:M:S:nStep) ", HcoState%Clock%SimHour, ":", HcoState%Clock%SimMin, ":", HcoState%Clock%SimSec, " x", HcoState%Clock%nSteps
+            write(iulog,'(A,I4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2)') "HEMCO_CESM: Updating HEMCO clock to set (Y-M-D H:I:S) ", ts0_year, "-", ts0_month, "-", ts0_day, " ", hour, ":", minute, ":", second
+        endif
 
-        !if(masterproc) then
-        !    write(6,*) "HEMCO_CESM: Updating HEMCO clock to set", year, month, day, hour, minute, second
-        !    write(6,*) "HEMCO_CESM: Internally HEMCO is at ", HcoState%Clock%SimHour, HcoState%Clock%SimMin, HcoState%Clock%SimSec, HcoState%Clock%nSteps
-        !endif
-
-        call HCOClock_Set(HcoState, year, month, day,  &
+        call HCOClock_Set(HcoState, ts0_year, ts0_month, ts0_day,  &
                           hour, minute, second, IsEmisTime=.true., RC=HMRC)
         ASSERT_(HMRC==HCO_SUCCESS)
 
@@ -1590,9 +1572,8 @@ contains
             write(iulog,*) "THIS ERROR ORIGINATED WITHIN HEMCO!       "
             write(iulog,*) "A critical component in HEMCO failed to run."
             write(iulog,*) "This may be due to misconfiguration, or a bug."
-            write(iulog,*) "Please refer to the HEMCO.log log file in your"
-            write(iulog,*) "case run directory or as configured in HEMCO_Config.rc"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in your"
+            write(iulog,*) "case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
@@ -1606,9 +1587,8 @@ contains
             write(iulog,*) "THIS ERROR ORIGINATED WITHIN HEMCO!       "
             write(iulog,*) "A critical component in HEMCO failed to run."
             write(iulog,*) "This may be due to misconfiguration, or a bug."
-            write(iulog,*) "Please refer to the HEMCO.log log file in your"
-            write(iulog,*) "case run directory or as configured in HEMCO_Config.rc"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in your"
+            write(iulog,*) "case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
@@ -1625,9 +1605,8 @@ contains
             write(iulog,*) "THIS ERROR ORIGINATED WITHIN HEMCO!"
             write(iulog,*) "A critical component in HEMCO failed to run."
             write(iulog,*) "This may be due to misconfiguration, or a bug."
-            write(iulog,*) "Please refer to the HEMCO.log log file in your"
-            write(iulog,*) "case run directory or as configured in HEMCO_Config.rc"
-            write(iulog,*) "for more information."
+            write(iulog,*) "Please refer to the cesm.log log file in your"
+            write(iulog,*) "case run directory for more information."
             write(iulog,*) "******************************************"
         endif
         ASSERT_(HMRC==HCO_SUCCESS)
@@ -2458,9 +2437,6 @@ contains
         !-----------------------------------------------------------------------
         ! Finished!
         !-----------------------------------------------------------------------
-        ! Update last execution time
-        last_HCO_day    = now_day
-        last_HCO_second = now_s
 
         IF ( FIRST ) FIRST = .False.
 


### PR DESCRIPTION
HEMCO_CESM 2.1.0 is now included in CAM tag cam6_4_082. This PR brings it into main, on top of previous commits in main from @jimmielin for the README. Note that the version coming into main is already tagged as hemco_cesm2_1_0_hemco3_9_3. 